### PR TITLE
add _getColumnTypes to api.js

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -507,6 +507,14 @@ class Statement {
     return names;
   }
 
+  _getColumnTypes() {
+    const names = [];
+    const columns = sqlite3.column_count(this._ptr);
+    for (let i = 0; i < columns; i++)
+      names.push(sqlite3.column_type(this._ptr, i));
+    return names;
+  }
+
   _bindArray(values) {
     for (let i = 0; i < values.length; i++) this._bindValue(values[i], i + 1);
   }


### PR DESCRIPTION
Could this be added to the internal API? I want to tie this into prisma, but it seems that I need the declared column types to be returned, based on what I'm seeing from the other driver adapters they have. 

Obviously I know this would be an internal api, but it essentially lets me make a modified _queryRows function which gets the column types when it gets the column names and then return them along with the rows. 